### PR TITLE
[CHECKOUT_DATE_REF_COMMIT] - Added methods to checkout from hashes, refs, and before a date

### DIFF
--- a/src/main/java/edu/appstate/cs/rascalgit/RascalGit.java
+++ b/src/main/java/edu/appstate/cs/rascalgit/RascalGit.java
@@ -27,34 +27,22 @@ package edu.appstate.cs.rascalgit;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import org.eclipse.jgit.api.CheckoutCommand;
+import io.usethesource.vallang.*;
 import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.errors.CheckoutConflictException;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.api.errors.InvalidRefNameException;
 import org.eclipse.jgit.api.errors.InvalidRemoteException;
-import org.eclipse.jgit.api.errors.RefAlreadyExistsException;
-import org.eclipse.jgit.api.errors.RefNotFoundException;
 import org.eclipse.jgit.api.errors.TransportException;
 import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevSort;
 import org.eclipse.jgit.revwalk.RevWalk;
 import org.rascalmpl.exceptions.RuntimeExceptionFactory;
-
-import io.usethesource.vallang.IConstructor;
-import io.usethesource.vallang.IDateTime;
-import io.usethesource.vallang.IInteger;
-import io.usethesource.vallang.IList;
-import io.usethesource.vallang.IListWriter;
-import io.usethesource.vallang.ISourceLocation;
-import io.usethesource.vallang.IString;
-import io.usethesource.vallang.IValueFactory;
 
 public class RascalGit {
 	private final IValueFactory values;
@@ -149,6 +137,134 @@ public class RascalGit {
             }
         }
         throw RuntimeExceptionFactory.illegalArgument(loc,"Repository not open");
+    }
+
+    public void checkoutByDate(ISourceLocation loc, IDateTime refDate) {
+        if (repoMap.containsKey(loc)) {
+            File repoDir = new File(loc.getPath());
+            try {
+                Git git = Git.open(repoDir);
+                Repository repository = git.getRepository();
+                RevCommit targetCommit = null;
+                try (RevWalk walk = new RevWalk(repository)) {
+
+                    RevCommit head = walk.parseCommit(repository.resolve("HEAD"));
+                    walk.markStart(head);
+
+                    walk.sort(RevSort.COMMIT_TIME_DESC);
+
+                    for (RevCommit commit : walk) {
+
+                        long targetMillis = refDate.getInstant();
+                        long commitMillis = commit.getCommitTime() * 1000L;
+                        if (commitMillis <= targetMillis) {
+                            targetCommit = commit;
+                            break;
+                        }
+                    }
+                    if (targetCommit != null) {
+                        git.checkout()
+                                .setName(targetCommit.getId().getName())
+                                .call();
+                    }
+                }
+            } catch (GitAPIException ge) {
+                throw RuntimeExceptionFactory.javaException(ge, null, null);
+            } catch (IOException e) {
+                throw RuntimeExceptionFactory.javaException(e, null, null);
+            }
+        }
+    }
+
+    public void switchCommit(ISourceLocation loc, IString commitHash) {
+        if (repoMap.containsKey(loc)) {
+            Repository repo = repoMap.get(loc);
+            File repoDir = new File(loc.getPath());
+            String target = commitHash.getValue();
+            try {
+                Git git = Git.open(repoDir);
+                ObjectId id = repo.resolve(target);
+                if(id != null) {
+                    git.checkout().setName(target).call();
+                } else {
+                    throw RuntimeExceptionFactory.illegalArgument(loc, "Invalid hash reference");
+                }
+
+            } catch (GitAPIException ge) {
+                throw RuntimeExceptionFactory.javaException(ge, null, null);
+            } catch (IOException e) {
+                throw RuntimeExceptionFactory.javaException(e, null, null);
+            }
+        }
+    }
+
+    public void switchRef(ISourceLocation loc, IString refName) {
+        if (repoMap.containsKey(loc)) {
+            Repository repo = repoMap.get(loc);
+            File repoDir = new File(loc.getPath());
+            String target = refName.getValue();
+            try {
+                Git git = Git.open(repoDir);
+                String fullRefName = Constants.R_HEADS + refName;
+                ObjectId id = repo.resolve(fullRefName);
+                if(id != null) {
+                    git.checkout().setName(fullRefName).setStartPoint(fullRefName).call();
+                } else {
+                    throw RuntimeExceptionFactory.illegalArgument(loc, "Invalid ref reference");
+                }
+            } catch (GitAPIException ge) {
+                throw RuntimeExceptionFactory.javaException(ge, null, null);
+            } catch (IOException e) {
+                throw RuntimeExceptionFactory.javaException(e, null, null);
+            }
+        }
+    }
+
+    public IDateTime getCommitDate(ISourceLocation loc, IString commitHash) {
+        if (repoMap.containsKey(loc)) {
+            Repository repo = repoMap.get(loc);
+            try {
+                ObjectId id = repo.resolve(commitHash.getValue());
+                if (id == null) {
+                    throw RuntimeExceptionFactory.illegalArgument(loc, "Invalid ref reference");
+                }
+                RevWalk revWalk = new RevWalk(repo);
+                RevCommit commit = revWalk.parseCommit(repo.resolve(commitHash.getValue()));
+                long instant = 1000L * commit.getCommitTime();
+                IDateTime commitTime = values.datetime(instant);
+                return commitTime;
+            } catch (IOException e) {
+                throw RuntimeExceptionFactory.javaException(e, null, null);
+            }
+        }
+        throw RuntimeExceptionFactory.illegalArgument(loc,"Repository not open");
+    }
+
+    public IList getCommitLog(ISourceLocation loc, IBool reverse) {
+        if (repoMap.containsKey(loc)) {
+            Repository repo = repoMap.get(loc);
+            IListWriter listWriter = values.listWriter();
+            try {
+                RevWalk revWalk = new RevWalk(repo);
+                RevCommit commit = revWalk.parseCommit(repo.resolve("HEAD"));
+                revWalk.markStart(commit);
+                if (reverse.getValue()) {
+                    revWalk.sort(RevSort.REVERSE);
+                } else {
+                    revWalk.sort(RevSort.NONE);
+                }
+                for (RevCommit revCommit : revWalk) {
+                    String hash = revCommit.getId().getName();
+                    long commitMillis = revCommit.getCommitTime() * 1000L;
+
+                    ITuple commitTuple = values.tuple(values.string(hash), values.datetime(commitMillis));
+                    listWriter.append(commitTuple);
+                }
+                return listWriter.done();
+            } catch (IOException e) {
+                throw RuntimeExceptionFactory.javaException(e, null, null);
+            }
+        } throw RuntimeExceptionFactory.illegalArgument(loc,"Repository not open");
     }
 	
 }

--- a/src/main/rascal/util/git/Git.rsc
+++ b/src/main/rascal/util/git/Git.rsc
@@ -57,3 +57,29 @@ java void switchToTag(loc repoPath, str \tag);
 @javaClass{edu.appstate.cs.rascalgit.RascalGit}
 @synopsis{`git log -1 --format=%ai myTagName`}
 java datetime getTagCommitDate(loc repoPath, str \tag);
+
+@javaClass{edu.appstate.cs.rascalgit.RascalGit}
+@synopsis{`git checkout `git rev-list -n 1 --before="2023-01-01 12:00:00" HEAD``}
+@description{
+This will checkout the most recent commit before the given date.
+}
+java void checkoutByDate(loc repoPath, datetime refDate);
+
+@javaClass{edu.appstate.cs.rascalgit.RascalGit}
+@synopsis{`git checkout myfeaturebranch`}
+java void switchRef(loc repoPath, str refName);
+
+@javaClass{edu.appstate.cs.rascalgit.RascalGit}
+@synopsis{`git checkout commmithash`}
+java void switchCommit(loc repoPath, str commitHash);
+
+@javaClass{edu.appstate.cs.rascalgit.RascalGit}
+@synopsis{`git show -s --format=%cI commithash`}
+java datetime getCommitDate(loc repoPath, str commitHash);
+
+@javaClass{edu.appstate.cs.rascalgit.RascalGit}
+@synopsis{`git log [--reverse] --format="%H,%ct"`}
+@description{
+This will return a list of tuples of the commit hash and the commit date.
+}
+public java list[tuple[str hash, datetime date]] getCommitLog(loc repoPath, bool reverse);


### PR DESCRIPTION
This pull request contains method, which allow to checkout out a repository, based on a commit hash, a ref/branch, or before a specific date. It also contains helper methods to return the commit log and to a date of a specific commit hash.